### PR TITLE
Yatagarasuクラスのバグを修正

### DIFF
--- a/Yatagarasu.java
+++ b/Yatagarasu.java
@@ -15,7 +15,7 @@ public class Yatagarasu extends Monster implements Bird {
 	*/
 	public Yatagarasu() {
 		super.setHp(100);
-		super.setName("八咫烏");
+		super.setName("ななし");
 		super.setExp(50);
 	}
 
@@ -35,19 +35,19 @@ public class Yatagarasu extends Monster implements Bird {
 	* ヤタガラスの死
 	*/
 	public void dead() {
-		System.out.println(getName()+"は死んだ");
+		System.out.println(this.getName()+"は死んだ");
 	}
 
 	/**
 	* ヤタガラスの疾走
 	*/
 	public void run() {
-		System.out.print("ヤタガラスは走った！");
+		System.out.println(this.getName() + "は走った！");
 		return;
 	}
 
 	public void fry(){
-		System.out.print("ヤタガラス飛翔！");
+		System.out.println(this.getName() + "飛翔！");
 		return;
 	}
 

--- a/Yatagarasu.java
+++ b/Yatagarasu.java
@@ -35,7 +35,7 @@ public class Yatagarasu extends Monster implements Bird {
 	* ヤタガラスの死
 	*/
 	public void dead() {
-		System.out.println(this.getName()+"は死んだ");
+		System.out.println(this.getName() + "は死んだ");
 	}
 
 	/**


### PR DESCRIPTION
以下のバグを修正
- 引数なしのコンストラクタで`name`が「ななし」になるよう修正
- `dead()`のメッセージで表示名が固定になっているのを`name`の値になるよう修正
- `fry()`のメッセージで表示名が固定になっているのを`name`の値になるよう修正